### PR TITLE
:sparkle: Add 2024 Day 17 chronospatial computer solution

### DIFF
--- a/aoc-2024/src/main/kotlin/com/capital7software/aoc/aoc2024aoc/days/Day17.kt
+++ b/aoc-2024/src/main/kotlin/com/capital7software/aoc/aoc2024aoc/days/Day17.kt
@@ -1,0 +1,189 @@
+package com.capital7software.aoc.aoc2024aoc.days
+
+import com.capital7software.aoc.lib.AdventOfCodeSolution
+import com.capital7software.aoc.lib.computer.ChronospatialComputer
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import kotlin.system.measureNanoTime
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * ***--- Day 17: Chronospatial Computer ---***
+ *
+ * The Historians push the button on their strange device, but this time, you all just feel like
+ * you're [falling](https://adventofcode.com/2018/day/6).
+ *
+ * "Situation critical", the device announces in a familiar voice. "Bootstrapping process failed.
+ * Initializing debugger...."
+ *
+ * The small handheld device suddenly unfolds into an entire computer! The Historians look around
+ * nervously before one of them tosses it to you.
+ *
+ * This seems to be a 3-bit computer: its program is a list of 3-bit numbers (0 through 7), like
+ * `0,1,2,3`. The computer also has three **registers** named `A`, `B`, and `C`, but these
+ * registers aren't limited to 3 bits and can instead hold any integer.
+ *
+ * The computer knows **eight instructions**, each identified by a 3-bit number (called the
+ * instruction's **opcode**). Each instruction also reads the 3-bit number after it as an input;
+ * this is called its **operand**.
+ *
+ * A number called the **instruction pointer** identifies the position in the program from which
+ * the next opcode will be read; it starts at `0`, pointing at the first 3-bit number in the
+ * program. Except for jump instructions, the instruction pointer increases by `2` after each
+ * instruction is processed (to move past the instruction's opcode and its operand). If the
+ * computer tries to read an opcode past the end of the program, it instead **halts**.
+ *
+ * So, the program `0,1,2,3` would run the instruction whose opcode is `0` and pass it the operand
+ * `1`, then run the instruction having opcode `2` and pass it the operand `3`, then halt.
+ *
+ * There are two types of operands; each instruction specifies the type of its operand. The value
+ * of a **literal operand** is the operand itself. For example, the value of the literal operand
+ * `7` is the number `7`. The value of a **combo operand** can be found as follows:
+ *
+ * - Combo operands `0` through `3` represent literal values `0` through `3`.
+ * - Combo operand `4` represents the value of register `A`.
+ * - Combo operand `5` represents the value of register `B`.
+ * - Combo operand `6` represents the value of register `C`.
+ * - Combo operand `7` is reserved and will not appear in valid programs.
+ *
+ * The eight instructions are as follows:
+ *
+ * The **`adv`** instruction (opcode **`0`**) performs **division**. The numerator is the value in
+ * the `A` register. The denominator is found by raising 2 to the power of the instruction's
+ * **combo** operand. (So, an operand of `2` would divide `A` by `4` (`2^2`); an operand of `5`
+ * would divide `A` by `2^B`.) The result of the division operation is **truncated** to an integer
+ * and then written to the `A` register.
+ *
+ * The **`bxl`** instruction (opcode **`1`**) calculates the
+ * [bitwise XOR](https://en.wikipedia.org/wiki/Bitwise_operation#XOR) of register `B` and the
+ * instruction's **literal** operand, then stores the result in register `B`.
+ *
+ * The **`bst`** instruction (opcode **`2`**) calculates the value of its **combo** operand
+ * [modulo](https://en.wikipedia.org/wiki/Modulo) 8 (thereby keeping only its lowest 3 bits), then
+ * writes that value to the `B` register.
+ *
+ * The **`jnz`** instruction (opcode **`3`**) does **nothing** if the `A` register is `0`. However,
+ * if the `A` register is **not zero**, it **jumps** by setting the instruction pointer to the value
+ * of its **literal** operand; if this instruction jumps, the instruction pointer is **not**
+ * increased by `2` after this instruction.
+ *
+ * The **`bxc`** instruction (opcode **`4`**) calculates the **bitwise XOR** of register `B` and
+ * register `C`, then stores the result in register `B`. (For legacy reasons, this instruction
+ * reads an operand but **ignores** it.)
+ *
+ * The **`out`** instruction (opcode **`5`**) calculates the value of its **combo** operand modulo
+ * 8, then **outputs** that value. (If a program outputs multiple values, they are separated by
+ * commas.)
+ *
+ * The **`bdv`** instruction (opcode **`6`**) works exactly like the `adv` instruction except that the
+ * result is stored in the **`B` register**. (The numerator is still read from the `A` register.)
+ *
+ * The **`cdv`** instruction (opcode **`7`**) works exactly like the `adv` instruction except that the
+ * result is stored in the **`C` register**. (The numerator is still read from the `A` register.)
+ *
+ * Here are some examples of instruction operation:
+ *
+ * - If register `C` contains `9`, the program `2,6` would set register `B` to `1`.
+ * - If register `A` contains `10`, the program `5,0,5,1,5,4` would output `0,1,2`.
+ * - If register `A` contains `2024`, the program `0,1,5,4,3,0` would output
+ * `4,2,5,6,7,7,7,7,3,1,0` and leave `0` in register `A`.
+ * - If register `B` contains `29`, the program `1,7` would set register `B` to `26`.
+ * - If register `B` contains `2024` and register `C` contains `43690`, the program `4,0`
+ * would set register `B` to `44354`.
+ *
+ * The Historians' strange device has finished initializing its debugger and is displaying some
+ * **information about the program it is trying to run** (your puzzle input). For example:
+ *
+ * ```
+ * Register A: 729
+ * Register B: 0
+ * Register C: 0
+ *
+ * Program: 0,1,5,4,3,0
+ * ```
+ *
+ * Your first task is to **determine what the program is trying to output**. To do this, initialize
+ * the registers to the given values, then run the given program, collecting any output produced
+ * by `out` instructions. (Always join the values produced by `out` instructions with commas.)
+ * After the above program halts, its final output will be **`4,6,3,5,6,3,5,2,1,0`**.
+ *
+ * Using the information provided by the debugger, initialize the registers to the given values,
+ * then run the program. Once it halts, **what do you get if you use commas to join the values it
+ * output into a single string?**
+ *
+ * Your puzzle answer was **`7,3,5,7,5,7,4,3,0`**.
+ *
+ * **--- Part Two ---**
+ *
+ * Digging deeper in the device's manual, you discover the problem: this program is supposed to
+ * **output another copy of the program**! Unfortunately, the value in register `A` seems to have
+ * been corrupted. You'll need to find a new value to which you can initialize register `A` so
+ * that the program's output instructions produce an exact copy of the program itself.
+ *
+ * For example:
+ *
+ * ```
+ * Register A: 2024
+ * Register B: 0
+ * Register C: 0
+ *
+ * Program: 0,3,5,4,3,0
+ * ```
+ *
+ * This program outputs a copy of itself if register `A` is instead initialized to
+ * **`117440**`. (The original initial value of register `A`, `2024`, is ignored.)
+ *
+ * **What is the lowest positive initial value for register A that causes the program to output a
+ * copy of itself?
+ *
+ * Your puzzle answer was **`105734774294938`**.
+ */
+class Day17 : AdventOfCodeSolution {
+  private companion object {
+    private val log: Logger = LoggerFactory.getLogger(Day17::class.java)
+  }
+
+  override fun getDefaultInputFilename(): String = "inputs/input_day_17-01.txt"
+
+  @SuppressFBWarnings
+  override fun runPart1(input: List<String>) {
+    lateinit var answer: String
+    val elapsed = measureNanoTime {
+      answer = programOutput(input)
+    }
+    log.info("$answer is the output of the chronospatial computer!")
+    logTimings(log, elapsed)
+  }
+
+  override fun runPart2(input: List<String>) {
+    var answer: Long
+    val elapsed = measureNanoTime {
+      answer = lowestPositiveInitialRegisterA(input)
+    }
+    log.info("$answer is the lowest positive initial value for register A!")
+    logTimings(log, elapsed)
+  }
+
+  /**
+   * Initializes the chronospatial computer from the debugger output, runs the program until it
+   * halts, and returns the emitted values joined by commas.
+   *
+   * @param input The debugger output containing the initial registers and program.
+   * @return The emitted output values joined by commas.
+   */
+  fun programOutput(input: List<String>): String {
+    return ChronospatialComputer.load(input).runToString()
+  }
+
+  /**
+   * Returns the lowest positive initial value for register `A` that causes the program to output
+   * an exact copy of itself.
+   *
+   * @param input The debugger output containing the initial registers and program.
+   * @return The lowest positive initial value for register `A`.
+   */
+  fun lowestPositiveInitialRegisterA(input: List<String>): Long {
+    return ChronospatialComputer.load(input)
+        .lowestPositiveInitialRegisterAForProgramCopy()
+  }
+}

--- a/aoc-2024/src/main/resources/inputs/input_day_17-01.txt
+++ b/aoc-2024/src/main/resources/inputs/input_day_17-01.txt
@@ -1,0 +1,5 @@
+Register A: 61156655
+Register B: 0
+Register C: 0
+
+Program: 2,4,1,5,7,5,4,3,1,6,0,3,5,5,3,0

--- a/aoc-2024/src/test/kotlin/com/capital7software/aoc/aoc2024aoc/days/Day17Test.kt
+++ b/aoc-2024/src/test/kotlin/com/capital7software/aoc/aoc2024aoc/days/Day17Test.kt
@@ -1,0 +1,213 @@
+package com.capital7software.aoc.aoc2024aoc.days
+
+import com.capital7software.aoc.lib.AdventOfCodeTestBase
+import com.capital7software.aoc.lib.computer.ChronospatialComputer
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class Day17Test : AdventOfCodeTestBase() {
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(Day17Test::class.java)
+  }
+
+  override fun getLogger(): Logger {
+    return log
+  }
+
+  @BeforeEach
+  fun setup() {
+    val instance = Day17()
+    setupFromFile(instance.defaultInputFilename)
+  }
+
+  @Test
+  fun testProgramOutputExample() {
+    val expected = "4,6,3,5,6,3,5,2,1,0"
+
+    val actual = Day17().programOutput(lines)
+
+    Assertions.assertEquals(
+        expected,
+        actual,
+        "The program output $actual is not the expected output $expected."
+    )
+  }
+
+  @Test
+  fun testProgramOutputExample2() {
+    setupFromFile("inputs/input_day_17-02.txt")
+
+    val expected = 117440L
+    val actual = Day17().lowestPositiveInitialRegisterA(lines)
+
+    Assertions.assertEquals(
+        expected,
+        actual,
+        "The lowest value for Register A $actual is not the expected lowest value $expected."
+    )
+  }
+
+  @Test
+  fun testComboOperandCanReadRegisterC() {
+    val input = listOf(
+        "Register A: 0",
+        "Register B: 0",
+        "Register C: 9",
+        "",
+        "Program: 2,6"
+    )
+
+    val computer = ChronospatialComputer.load(input)
+    computer.run()
+
+    Assertions.assertEquals(
+        1L,
+        computer["B"],
+        "Register B should contain 1 after executing bst with combo operand C."
+    )
+  }
+
+  @Test
+  fun testOutputInstruction() {
+    val input = listOf(
+        "Register A: 10",
+        "Register B: 0",
+        "Register C: 0",
+        "",
+        "Program: 5,0,5,1,5,4"
+    )
+    val expected = "0,1,2"
+
+    val actual = ChronospatialComputer.load(input).runToString()
+
+    Assertions.assertEquals(
+        expected,
+        actual,
+        "The program output $actual is not the expected output $expected."
+    )
+  }
+
+  @Test
+  fun testAdvAndJnzLoopExample() {
+    val input = listOf(
+        "Register A: 2024",
+        "Register B: 0",
+        "Register C: 0",
+        "",
+        "Program: 0,1,5,4,3,0"
+    )
+    val expected = "4,2,5,6,7,7,7,7,3,1,0"
+
+    val computer = ChronospatialComputer.load(input)
+    val actual = computer.runToString()
+
+    Assertions.assertEquals(
+        expected,
+        actual,
+        "The program output $actual is not the expected output $expected."
+    )
+    Assertions.assertEquals(
+        0L,
+        computer["A"],
+        "Register A should contain 0 after the program halts."
+    )
+  }
+
+  @Test
+  fun testLiteralXor() {
+    val input = listOf(
+        "Register A: 0",
+        "Register B: 29",
+        "Register C: 0",
+        "",
+        "Program: 1,7"
+    )
+
+    val computer = ChronospatialComputer.load(input)
+    computer.run()
+
+    Assertions.assertEquals(
+        26L,
+        computer["B"],
+        "Register B should contain 26 after XOR with literal 7."
+    )
+  }
+
+  @Test
+  fun testRegisterXor() {
+    val input = listOf(
+        "Register A: 0",
+        "Register B: 2024",
+        "Register C: 43690",
+        "",
+        "Program: 4,0"
+    )
+
+    val computer = ChronospatialComputer.load(input)
+    computer.run()
+
+    Assertions.assertEquals(
+        44354L,
+        computer["B"],
+        "Register B should contain 44354 after XOR with register C."
+    )
+  }
+
+  @Test
+  fun testProgramOutput() {
+    val instance = Day17()
+
+    val actual = instance.programOutput(lines)
+
+    Assertions.assertTrue(
+        actual.matches("""\d(?:,\d)*""".toRegex()),
+        "The program output should be a comma-separated list of 3-bit values."
+    )
+  }
+
+  @Test
+  fun testLowestPositiveInitialRegisterAProducesProgramCopyExample() {
+    val input = listOf(
+        "Register A: 2024",
+        "Register B: 0",
+        "Register C: 0",
+        "",
+        "Program: 0,3,5,4,3,0"
+    )
+    val expectedProgram = listOf(0, 3, 5, 4, 3, 0)
+
+    val registerA = ChronospatialComputer.load(
+        input
+    ).lowestPositiveInitialRegisterAForProgramCopy()
+
+    val computer = ChronospatialComputer.load(input)
+    computer["A"] = registerA
+    val actual = computer.run()
+
+    Assertions.assertEquals(
+        expectedProgram,
+        actual,
+        "The program output $actual is not an exact copy of $expectedProgram."
+    )
+  }
+
+  @Test
+  fun testLowestPositiveInitialRegisterA() {
+    val instance = Day17()
+
+    setupFromFile("inputs/input_day_17-03.txt")
+
+    val expected = 105734774294938L
+
+    val actual = instance.lowestPositiveInitialRegisterA(lines)
+
+    Assertions.assertEquals(
+        expected,
+        actual,
+        "The lowest positive initial register A value $actual is not the expected value $expected."
+    )
+  }
+}

--- a/aoc-2024/src/test/resources/inputs/input_day_17-01.txt
+++ b/aoc-2024/src/test/resources/inputs/input_day_17-01.txt
@@ -1,0 +1,5 @@
+Register A: 729
+Register B: 0
+Register C: 0
+
+Program: 0,1,5,4,3,0

--- a/aoc-2024/src/test/resources/inputs/input_day_17-02.txt
+++ b/aoc-2024/src/test/resources/inputs/input_day_17-02.txt
@@ -1,0 +1,5 @@
+Register A: 2024
+Register B: 0
+Register C: 0
+
+Program: 0,3,5,4,3,0

--- a/aoc-2024/src/test/resources/inputs/input_day_17-03.txt
+++ b/aoc-2024/src/test/resources/inputs/input_day_17-03.txt
@@ -1,0 +1,5 @@
+Register A: 61156655
+Register B: 0
+Register C: 0
+
+Program: 2,4,1,5,7,5,4,3,1,6,0,3,5,5,3,0

--- a/aoc-library/src/main/kotlin/com/capital7software/aoc/lib/computer/ChronospatialComputer.kt
+++ b/aoc-library/src/main/kotlin/com/capital7software/aoc/lib/computer/ChronospatialComputer.kt
@@ -1,0 +1,322 @@
+package com.capital7software.aoc.lib.computer
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+
+/**
+ * A small 3-bit computer used by the Historians' debugger.
+ *
+ * The program is encoded as a flat list of 3-bit values. Each instruction is two values:
+ *
+ * - opcode
+ * - operand
+ *
+ * The instruction pointer points directly into that flat program list. Therefore, normal
+ * instruction advancement is by `2`, while `jnz` assigns the pointer directly to its literal
+ * operand.
+ *
+ * Registers `A`, `B`, and `C` are not limited to 3 bits and are represented as [Long] values.
+ *
+ * @param registerA The initial value of register `A`.
+ * @param registerB The initial value of register `B`.
+ * @param registerC The initial value of register `C`.
+ * @param program The flat list of opcode / operand values.
+ */
+@SuppressFBWarnings
+class ChronospatialComputer private constructor(
+    registerA: Long,
+    registerB: Long,
+    registerC: Long,
+    val program: List<Int>
+) {
+  private val initialRegisterB: Long = registerB
+  private val initialRegisterC: Long = registerC
+
+  private val registers: MutableMap<String, Register> = mutableMapOf(
+      REGISTER_A to Register(REGISTER_A, registerA),
+      REGISTER_B to Register(REGISTER_B, registerB),
+      REGISTER_C to Register(REGISTER_C, registerC)
+  )
+
+  private var instructionPointer: Int = 0
+  private val output: MutableList<Int> = mutableListOf()
+
+  /**
+   * Static factory and parsing helpers for [ChronospatialComputer].
+   */
+  companion object {
+    private const val REGISTER_A = "A"
+    private const val REGISTER_B = "B"
+    private const val REGISTER_C = "C"
+    private const val REGISTER_A_DIGIT_COUNT = 8
+
+    private val RegisterRegex = """^Register (?<register>[ABC]): (?<value>-?\d+)$""".toRegex()
+    private val ProgramRegex = """^Program: (?<program>[0-7](?:,[0-7])*)$""".toRegex()
+
+    /**
+     * Parses debugger output into a new [ChronospatialComputer].
+     *
+     * Expected input shape:
+     *
+     * ```
+     * Register A: 729
+     * Register B: 0
+     * Register C: 0
+     *
+     * Program: 0,1,5,4,3,0
+     * ```
+     *
+     * Blank lines are ignored.
+     *
+     * @param input The raw puzzle input.
+     * @return A new [ChronospatialComputer] initialized from [input].
+     */
+    fun load(
+        input: List<String>
+    ): ChronospatialComputer {
+      val registers = mutableMapOf(
+          REGISTER_A to 0L,
+          REGISTER_B to 0L,
+          REGISTER_C to 0L
+      )
+      var program: List<Int>? = null
+
+      input.filter { it.isNotBlank() }.forEach { line ->
+        val registerMatch = RegisterRegex.matchEntire(line)
+        val programMatch = ProgramRegex.matchEntire(line)
+
+        when {
+          registerMatch != null -> {
+            val register = registerMatch.groups["register"]?.value
+                ?: error("Unable to parse register from line: $line")
+            val value = registerMatch.groups["value"]?.value?.toLong()
+                ?: error("Unable to parse register value from line: $line")
+
+            registers[register] = value
+          }
+
+          programMatch != null -> {
+            program = programMatch.groups["program"]?.value
+                ?.split(',')
+                ?.map { it.toInt() }
+                ?: error("Unable to parse program from line: $line")
+          }
+
+          else -> error("Unable to parse debugger line: $line")
+        }
+      }
+
+      return ChronospatialComputer(
+          registerA = registers[REGISTER_A] ?: 0L,
+          registerB = registers[REGISTER_B] ?: 0L,
+          registerC = registers[REGISTER_C] ?: 0L,
+          program = program ?: error("No program was found in the input")
+      )
+    }
+  }
+
+  /**
+   * Returns the current value of the specified register.
+   *
+   * @param register The register name: `A`, `B`, or `C`.
+   * @return The current value of the specified register.
+   */
+  operator fun get(register: String): Long {
+    return registers[register]?.value ?: error("Unknown register: $register")
+  }
+
+  /**
+   * Sets the current value of the specified register.
+   *
+   * @param register The register name: `A`, `B`, or `C`.
+   * @param value The value to store.
+   */
+  operator fun set(register: String, value: Long) {
+    registers[register]?.value = value
+  }
+
+  /**
+   * Executes the loaded program until the instruction pointer attempts to read an opcode past the
+   * end of the program.
+   *
+   * @return The output values produced by all `out` instructions.
+   */
+  fun run(): List<Int> {
+    while (instructionPointer in program.indices) {
+      step()
+    }
+
+    return output.toList()
+  }
+
+  /**
+   * Executes the loaded program and returns all output values joined by commas.
+   *
+   * @return The program output as a comma-separated [String].
+   */
+  fun runToString(): String = run().joinToString(",")
+
+  /**
+   * Returns the lowest positive initial value for register `A` that causes this computer's output
+   * to exactly reproduce its own program.
+   *
+   * The original initial value of register `A` is intentionally ignored for this search. The initial
+   * values of registers `B` and `C` are preserved.
+   *
+   * This method is available on all instances, but callers should normally construct the computer
+   * with `ChronospatialComputer.load(input, true)` to make the Part 2 intent explicit.
+   *
+   * @return The lowest positive initial value for register `A`.
+   */
+  fun lowestPositiveInitialRegisterAForProgramCopy(): Long {
+    return findLowestProgramCopyRegisterA()
+  }
+
+  private fun findLowestProgramCopyRegisterA(): Long {
+    var candidates = setOf(0L)
+
+    for (index in program.indices.reversed()) {
+      val expected = program.drop(index)
+      val nextCandidates = mutableSetOf<Long>()
+
+      candidates.forEach { candidate ->
+        for (digit in 0 until REGISTER_A_DIGIT_COUNT) {
+          val next = candidate * REGISTER_A_DIGIT_COUNT + digit
+
+          if (next <= 0) {
+            continue
+          }
+
+          val actual = execute(
+              registerA = next,
+              registerB = initialRegisterB,
+              registerC = initialRegisterC,
+              maxOutput = expected.size
+          )
+
+          if (actual == expected) {
+            nextCandidates.add(next)
+          }
+        }
+      }
+
+      candidates = nextCandidates
+
+      check(candidates.isNotEmpty()) {
+        "Unable to find any register A candidates that emit expected suffix: $expected"
+      }
+    }
+
+    return candidates.min()
+  }
+
+  private fun execute(
+      registerA: Long,
+      registerB: Long,
+      registerC: Long,
+      maxOutput: Int = Int.MAX_VALUE
+  ): List<Int> {
+    val computer = ChronospatialComputer(
+        registerA = registerA,
+        registerB = registerB,
+        registerC = registerC,
+        program = program,
+    )
+
+    while (computer.instructionPointer in computer.program.indices &&
+        computer.output.size < maxOutput) {
+      computer.step()
+    }
+
+    return computer.output.toList()
+  }
+
+  private fun step() {
+    val opcode = program[instructionPointer]
+    val operand = program.getOrNull(instructionPointer + 1)
+        ?: error("Missing operand for opcode $opcode at position $instructionPointer")
+
+    when (opcode) {
+      0 -> adv(operand)
+      1 -> bxl(operand)
+      2 -> bst(operand)
+      3 -> jnz(operand)
+      4 -> bxc()
+      5 -> out(operand)
+      6 -> bdv(operand)
+      7 -> cdv(operand)
+      else -> error("Invalid opcode: $opcode")
+    }
+  }
+
+  private fun adv(operand: Int) {
+    this[REGISTER_A] = divideRegisterAByPowerOfTwo(operand)
+    instructionPointer += 2
+  }
+
+  private fun bxl(operand: Int) {
+    this[REGISTER_B] = this[REGISTER_B] xor operand.toLong()
+    instructionPointer += 2
+  }
+
+  private fun bst(operand: Int) {
+    this[REGISTER_B] = combo(operand) modulo REGISTER_A_DIGIT_COUNT
+    instructionPointer += 2
+  }
+
+  private fun jnz(operand: Int) {
+    instructionPointer = if (this[REGISTER_A] == 0L) {
+      instructionPointer + 2
+    } else {
+      operand
+    }
+  }
+
+  private fun bxc() {
+    this[REGISTER_B] = this[REGISTER_B] xor this[REGISTER_C]
+    instructionPointer += 2
+  }
+
+  private fun out(operand: Int) {
+    output.add((combo(operand) modulo REGISTER_A_DIGIT_COUNT).toInt())
+    instructionPointer += 2
+  }
+
+  private fun bdv(operand: Int) {
+    this[REGISTER_B] = divideRegisterAByPowerOfTwo(operand)
+    instructionPointer += 2
+  }
+
+  private fun cdv(operand: Int) {
+    this[REGISTER_C] = divideRegisterAByPowerOfTwo(operand)
+    instructionPointer += 2
+  }
+
+  private fun divideRegisterAByPowerOfTwo(operand: Int): Long {
+    val exponent = combo(operand)
+
+    require(exponent >= 0) {
+      "Combo operand resolved to a negative exponent: $exponent"
+    }
+
+    return if (exponent >= Long.SIZE_BITS - 1) {
+      0L
+    } else {
+      this[REGISTER_A] / (1L shl exponent.toInt())
+    }
+  }
+
+  private fun combo(operand: Int): Long {
+    return when (operand) {
+      0, 1, 2, 3 -> operand.toLong()
+      4 -> this[REGISTER_A]
+      5 -> this[REGISTER_B]
+      6 -> this[REGISTER_C]
+      7 -> error("Combo operand 7 is reserved and is not valid")
+      else -> error("Invalid 3-bit operand: $operand")
+    }
+  }
+
+  private infix fun Long.modulo(divisor: Int): Long {
+    return ((this % divisor) + divisor) % divisor
+  }
+}


### PR DESCRIPTION
Implement the ChronospatialComputer library component for executing the 3-bit debugger program, including opcode handling, combo operands, register state, and comma-separated output generation.

Add the Advent of Code 2024 Day 17 solution wiring for both parts:
- Part 1 computes the debugger program output
- Part 2 finds the lowest positive Register A value that causes the program to output a copy of itself

Add Day 17 puzzle inputs and test fixtures, including example coverage for instruction behavior, program output, and the program-copy Register A search.